### PR TITLE
Refactor RouteComponentLifecycleWrapper, other funcs to be functional, fix keys list bug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,7 +91,7 @@ internals.renderRoute = function renderRoute(basePath) {
 
     return (route) => {
 
-        const { handleRedirect, cloneWithProps, keyForRoute } = internals;
+        const { handleRedirect } = internals;
 
         if (route.redirect) {
             return handleRedirect(basePath, route);
@@ -102,7 +102,8 @@ internals.renderRoute = function renderRoute(basePath) {
             exact,
             strict,
             sensitive,
-            component: RouteComponent
+            component: RouteComponent,
+            wrapFallbackWithComponent
         } = route;
 
         const normalizedPath = internals.concatPaths(basePath, path);
@@ -149,9 +150,9 @@ internals.renderRoute = function renderRoute(basePath) {
                         const Fallback = route.fallback || (route.props ? route.props.fallback : null) || null;
 
                         if (Fallback) {
-                            return (
+                            return !wrapFallbackWithComponent ? <Fallback {...routerProps} /> : (
                                 <RouteComponent {...routerProps}>
-                                    <Fallback />
+                                    <Fallback {...routerProps} />
                                 </RouteComponent>
                             );
                         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ const internals = {};
 exports.Routes = function Routes(props) {
 
     const { routes } = props;
-    const { keyForRoute, renderRoute } = internals;
+    const { keyForRoute, renderRoute, cloneWithProps } = internals;
 
     const renderBase = renderRoute('/');
 
@@ -18,7 +18,7 @@ exports.Routes = function Routes(props) {
             <Switch>
                 {routes.map(renderBase).map((route) => {
 
-                    return React.cloneElement(route, { key: keyForRoute(route) });
+                    return cloneWithProps(route, { key: keyForRoute(route) });
                 })}
             </Switch>
         );
@@ -44,6 +44,15 @@ internals.keyForRoute = (route) => {
         + !!route.sensitive
         + !!route.childRoutes
     );
+};
+
+internals.cloneWithProps = (element, props) => {
+
+    if (!element) {
+        return null;
+    }
+
+    return React.cloneElement(element, props);
 };
 
 internals.handleRedirect = (basePath, route) => {
@@ -91,7 +100,11 @@ internals.renderRoute = function renderRoute(basePath) {
         const normalizedPath = internals.concatPaths(basePath, route.path);
         const renderRouteFromPath = internals.renderRoute(normalizedPath);
         const RouteComponent = route.component || route.render;
-        const { RouteComponentLifecycleWrapper } = internals;
+
+        const {
+            RouteComponentLifecycleWrapper,
+            cloneWithProps
+        } = internals;
 
         return (
             <Route
@@ -115,12 +128,12 @@ internals.renderRoute = function renderRoute(basePath) {
                         : switcher;
 
                     if (RouteComponentLifecycleWrapper.trivial(route)) {
-                        return React.cloneElement(routeComponent, { route });
+                        return cloneWithProps(routeComponent, { route });
                     }
 
                     return (
                         <RouteComponentLifecycleWrapper {...props} {...route.props} route={route}>
-                            {React.cloneElement(routeComponent, { route })}
+                            {cloneWithProps(routeComponent, { route })}
                         </RouteComponentLifecycleWrapper>
                     );
                 }}
@@ -134,6 +147,8 @@ const { useEffect, useState } = React;
 internals.RouteComponentLifecycleWrapper = function RouteComponentLifecycleWrapper(props) {
 
     const { route } = props;
+
+    const { cloneWithProps } = internals;
 
     let {
         onMount,
@@ -176,7 +191,7 @@ internals.RouteComponentLifecycleWrapper = function RouteComponentLifecycleWrapp
 
     const toRender = !preResolved ? (fallback || null) : children;
 
-    return React.cloneElement(toRender, { route });
+    return !toRender ? toRender : cloneWithProps(toRender, { route });
 };
 
 internals.RouteComponentLifecycleWrapper.propTypes = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ internals.cloneWithProps = (element, props) => {
     return React.cloneElement(element, props);
 };
 
-internals.handleRedirect = (basePath, route) => {
+internals.handleRedirect = function HandleRedirect(basePath, route) {
 
     // Redirect is special and must be exclusive of other props
     const { redirect, ...rest } = route;
@@ -87,9 +87,9 @@ internals.handleRedirect = (basePath, route) => {
     return <Redirect {...redirectProps} />;
 };
 
-internals.renderRoute = function renderRoute(basePath) {
+internals.renderRoute = function RenderPath(basePath) {
 
-    return (route) => {
+    return function RenderRoute(route) {
 
         const { handleRedirect } = internals;
 
@@ -128,10 +128,12 @@ internals.renderRoute = function renderRoute(basePath) {
                         normalizedPath
                     };
 
-                    const render = () => {
+                    const render = function Render(renderProps) {
+
+                        const componentProps = { ...routerProps, ...renderProps };
 
                         return (
-                            <RouteComponent {...routerProps}>
+                            <RouteComponent {...componentProps}>
                                 {route.childRoutes && (
                                     <Switch>
                                         {route.childRoutes.map(renderRouteFromPath)}
@@ -145,14 +147,16 @@ internals.renderRoute = function renderRoute(basePath) {
                         return render();
                     }
 
-                    const renderFallback = () => {
+                    const renderFallback = function RenderFallback(renderProps) {
 
                         const Fallback = route.fallback || (route.props ? route.props.fallback : null) || null;
 
+                        const componentProps = { ...routerProps, ...renderProps };
+
                         if (Fallback) {
-                            return !wrapFallbackWithComponent ? <Fallback {...routerProps} /> : (
-                                <RouteComponent {...routerProps}>
-                                    <Fallback {...routerProps} />
+                            return !wrapFallbackWithComponent ? <Fallback {...componentProps} /> : (
+                                <RouteComponent {...componentProps}>
+                                    <Fallback {...componentProps} />
                                 </RouteComponent>
                             );
                         }
@@ -164,7 +168,9 @@ internals.renderRoute = function renderRoute(basePath) {
                         <RouteComponentLifecycleWrapper
                             route={route}
                             routerProps={routerProps}
+                            // eslint-disable-next-line react/jsx-no-bind
                             render={render}
+                            // eslint-disable-next-line react/jsx-no-bind
                             renderFallback={renderFallback}
                         />
                     );
@@ -174,25 +180,32 @@ internals.renderRoute = function renderRoute(basePath) {
     };
 };
 
-const { useEffect, useState } = React;
+const { useEffect, useState, useRef } = React;
 
 internals.RouteComponentLifecycleWrapper = function RouteComponentLifecycleWrapper(props) {
 
-    const { route, routerProps, render, renderFallback } = props;
+    // Freeze props to avoid rerender bugs
+    const propsSnapshotRef = useRef();
+    useEffect(() => {
 
-    let {
-        onMount,
-        onUnmount
-    } = route;
-
-    const noop = () => null;
-
-    onMount = onMount || noop;
-    onUnmount = onUnmount || noop;
+        propsSnapshotRef.current = props;
+    });
 
     const [isPreResolved, setIsPreResolved] = useState(false);
 
     useEffect(() => {
+
+        const { route, routerProps } = propsSnapshotRef.current;
+
+        let {
+            onMount,
+            onUnmount
+        } = route;
+
+        const noop = () => null;
+
+        onMount = onMount || noop;
+        onUnmount = onUnmount || noop;
 
         const runPre = async (func) => {
 
@@ -215,9 +228,12 @@ internals.RouteComponentLifecycleWrapper = function RouteComponentLifecycleWrapp
 
             onUnmount(routerProps);
         };
-    }, []);
+    }, [setIsPreResolved]);
 
-    return !isPreResolved ? renderFallback() : render();
+    // We know these 2 funcs specifically won't change over time
+    const { renderFallback, render, ...rest } = props;
+
+    return !isPreResolved ? renderFallback(rest) : render(rest);
 };
 
 internals.RouteComponentLifecycleWrapper.propTypes = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,50 +91,81 @@ internals.renderRoute = function renderRoute(basePath) {
 
     return (route) => {
 
-        const { handleRedirect } = internals;
+        const { handleRedirect, cloneWithProps, keyForRoute } = internals;
 
         if (route.redirect) {
             return handleRedirect(basePath, route);
         }
 
-        const normalizedPath = internals.concatPaths(basePath, route.path);
-        const renderRouteFromPath = internals.renderRoute(normalizedPath);
-        const RouteComponent = route.component || route.render;
-
         const {
-            RouteComponentLifecycleWrapper,
-            cloneWithProps
-        } = internals;
+            path,
+            exact,
+            strict,
+            sensitive,
+            component: RouteComponent
+        } = route;
+
+        const normalizedPath = internals.concatPaths(basePath, path);
+        // 'renderRouteFromPath' — It's a recursion excursion.`
+        const renderRouteFromPath = internals.renderRoute(normalizedPath);
+
+        const { RouteComponentLifecycleWrapper } = internals;
 
         return (
             <Route
                 key={normalizedPath}
                 path={normalizedPath}
-                exact={route.exact}
-                strict={route.strict}
-                sensitive={route.sensitive}
+                exact={exact}
+                strict={strict}
+                sensitive={sensitive}
                 render={(props) => {
 
-                    const switcher = route.childRoutes
-                        ? <Switch>{route.childRoutes.map(renderRouteFromPath)}</Switch>
-                        : null;
+                    const routerProps = {
+                        ...props,
+                        ...route.props,
+                        route,
+                        normalizedPath
+                    };
 
-                    const routeComponent = RouteComponent
-                        ? (
-                            <RouteComponent {...props} route={route}>
-                                {switcher}
+                    const render = () => {
+
+                        return (
+                            <RouteComponent {...routerProps}>
+                                {!route.childRoutes ? null : (
+                                    <Switch>
+                                        {route.childRoutes.map(renderRouteFromPath)}
+                                    </Switch>
+                                )}
                             </RouteComponent>
-                        )
-                        : switcher;
+                        );
+                    };
 
-                    if (RouteComponentLifecycleWrapper.trivial(route)) {
-                        return cloneWithProps(routeComponent, { route });
+                    if (RouteComponentLifecycleWrapper.isTrivialRoute(route)) {
+                        return render();
                     }
 
+                    const renderFallback = () => {
+
+                        const Fallback = route.fallback || (route.props ? route.props.fallback : null) || null;
+
+                        if (Fallback) {
+                            return (
+                                <RouteComponent {...routerProps}>
+                                    <Fallback />
+                                </RouteComponent>
+                            );
+                        }
+
+                        return null;
+                    };
+
                     return (
-                        <RouteComponentLifecycleWrapper {...props} {...route.props} route={route}>
-                            {cloneWithProps(routeComponent, { route })}
-                        </RouteComponentLifecycleWrapper>
+                        <RouteComponentLifecycleWrapper
+                            route={route}
+                            routerProps={routerProps}
+                            render={render}
+                            renderFallback={renderFallback}
+                        />
                     );
                 }}
             />
@@ -146,61 +177,59 @@ const { useEffect, useState } = React;
 
 internals.RouteComponentLifecycleWrapper = function RouteComponentLifecycleWrapper(props) {
 
-    const { route } = props;
-
-    const { cloneWithProps } = internals;
+    const { route, routerProps, render, renderFallback } = props;
 
     let {
         onMount,
         onUnmount
     } = route;
 
-    const { pre } = route;
-
     const noop = () => null;
 
     onMount = onMount || noop;
     onUnmount = onUnmount || noop;
 
-    const [preResolved, setPreResolved] = useState(false);
+    const [isPreResolved, setIsPreResolved] = useState(false);
 
     useEffect(() => {
 
         const runPre = async (func) => {
 
-            await func(props);
-            onMount(props);
-            setPreResolved(true);
+            await func(routerProps);
+            onMount(routerProps);
+            setIsPreResolved(true);
         };
 
-        if (!pre) {
-            onMount(props);
-            setPreResolved(true);
+        const { pre } = route;
+
+        if (pre) {
+            runPre(pre);
         }
         else {
-            runPre(pre);
+            onMount(routerProps);
+            setIsPreResolved(true);
         }
 
         return function cleanup() {
 
-            onUnmount(props);
+            onUnmount(routerProps);
         };
     }, []);
 
-    const { fallback, children } = props;
-
-    const toRender = !preResolved ? (fallback || null) : children;
-
-    return !toRender ? toRender : cloneWithProps(toRender, { route });
+    return !isPreResolved ? renderFallback() : render();
 };
 
 internals.RouteComponentLifecycleWrapper.propTypes = {
     route: T.object.isRequired
 };
 
-internals.RouteComponentLifecycleWrapper.trivial = (route) => {
+internals.RouteComponentLifecycleWrapper.isTrivialRoute = (route) => {
 
-    return !route.props && !route.pre && !route.onMount && !route.onUnmount;
+    if (!route) {
+        return true;
+    }
+
+    return !route.pre && !route.onMount && !route.onUnmount;
 };
 
 internals.concatPaths = (base, path) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -156,7 +156,7 @@ internals.renderRoute = function renderRoute(basePath) {
                             );
                         }
 
-                        return null;
+                        return <RouteComponent {...routerProps} />;
                     };
 
                     return (

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,139 +1,187 @@
 'use strict';
 
 const React = require('react');
-const PropTypes = require('prop-types');
+const T = require('prop-types');
 const { Switch, Route, Redirect } = require('react-router');
 
 const internals = {};
 
-exports.Routes = class Routes extends React.Component {
+exports.Routes = function Routes(props) {
 
-    render() {
+    const { routes } = props;
+    const { keyForRoute, renderRoute } = internals;
 
-        const { routes } = this.props;
-        const renderRoute = internals.renderRoute('/');
+    const renderBase = renderRoute('/');
 
-        return Array.isArray(routes) ?
-            <Switch>{routes.map(renderRoute)}</Switch> :
-            renderRoute(routes);
+    if (Array.isArray(routes)) {
+        return (
+            <Switch>
+                {routes.map(renderBase).map((route) => {
+
+                    return React.cloneElement(route, { key: keyForRoute(route) });
+                })}
+            </Switch>
+        );
     }
+
+    return renderBase(routes);
 };
 
 exports.Routes.propTypes = {
-    routes: PropTypes.oneOfType([
-        PropTypes.object,
-        PropTypes.arrayOf(PropTypes.object)
+    routes: T.oneOfType([
+        T.object,
+        T.arrayOf(T.object)
     ]).isRequired
 };
 
-internals.renderRoute = (basePath) => {
+internals.keyForRoute = (route) => {
+
+    return String(
+        route.path
+        + !!route.exact
+        + !!route.strict
+        + !!route.sensitive
+        + !!route.childRoutes
+    );
+};
+
+internals.handleRedirect = (basePath, route) => {
+
+    // Redirect is special and must be exclusive of other props
+    const { redirect, ...rest } = route;
+
+    if (Object.keys(rest).length !== 0) {
+        throw new Error(`No other properties are allowed alongside "redirect" in route configuration. Check childRoutes of "${basePath}".`);
+    }
+
+    const { from, to } = redirect;
+    const redirectProps = { ...redirect };
+
+    if (typeof from === 'string') {
+        // redirect.from must be relative
+        redirectProps.from = internals.concatPaths(basePath, from);
+    }
+
+    if (typeof to === 'string') {
+        // If redirect.to is absolute, leave it be. Otherwise make it relative
+        redirectProps.to = to.startsWith('/') ? to : internals.concatPaths(basePath, to);
+    }
+    else if (to && typeof to.pathname === 'string') {
+        // to is an object
+        redirectProps.to = {
+            ...redirectProps.to,
+            pathname: to.pathname.startsWith('/') ? to.pathname : internals.concatPaths(basePath, to.pathname)
+        };
+    }
+
+    return <Redirect {...redirectProps} />;
+};
+
+internals.renderRoute = function renderRoute(basePath) {
 
     return (route) => {
 
+        const { handleRedirect } = internals;
+
         if (route.redirect) {
-
-            // Redirect is special and must be exclusive of other props
-            const { redirect, ...rest } = route;
-
-            if (Object.keys(rest).length !== 0) {
-                throw new Error(`No other properties are allowed alongside "redirect" in route configuration. Check childRoutes of "${basePath}".`);
-            }
-
-            const { from, to } = redirect;
-            const redirectProps = { ...redirect };
-
-            if (typeof from === 'string') {
-                // redirect.from must be relative
-                redirectProps.from = internals.concatPaths(basePath, from);
-            }
-
-            if (typeof to === 'string') {
-                // If redirect.to is absolute, leave it be. Otherwise make it relative
-                redirectProps.to = to.startsWith('/') ? to : internals.concatPaths(basePath, to);
-            }
-            else if (to && typeof to.pathname === 'string') {
-                // to is an object
-                redirectProps.to = {
-                    ...redirectProps.to,
-                    pathname: to.pathname.startsWith('/') ? to.pathname : internals.concatPaths(basePath, to.pathname)
-                };
-            }
-
-            return <Redirect {...redirectProps} />;
+            return handleRedirect(basePath, route);
         }
 
         const normalizedPath = internals.concatPaths(basePath, route.path);
-        const renderRoute = internals.renderRoute(normalizedPath);
+        const renderRouteFromPath = internals.renderRoute(normalizedPath);
         const RouteComponent = route.component || route.render;
         const { RouteComponentLifecycleWrapper } = internals;
 
         return (
             <Route
-                key={route.path}
+                key={normalizedPath}
                 path={normalizedPath}
                 exact={route.exact}
                 strict={route.strict}
                 sensitive={route.sensitive}
                 render={(props) => {
 
-                    const switcher = route.childRoutes ?
-                        <Switch children={route.childRoutes.map(renderRoute)} /> :
-                        null;
+                    const switcher = route.childRoutes
+                        ? <Switch>{route.childRoutes.map(renderRouteFromPath)}</Switch>
+                        : null;
 
-                    const routeComponent = RouteComponent ?
-                        <RouteComponent {...props} route={route} children={switcher} /> :
-                        switcher;
+                    const routeComponent = RouteComponent
+                        ? <RouteComponent {...props} route={route} children={switcher} />
+                        : switcher;
 
-                    return RouteComponentLifecycleWrapper.nonTrivial(route) ?
-                        <RouteComponentLifecycleWrapper {...props} route={route} children={routeComponent} /> :
-                        routeComponent;
+                    if (RouteComponentLifecycleWrapper.trivial(route)) {
+                        return routeComponent;
+                    }
+
+                    return (
+                        <RouteComponentLifecycleWrapper {...props} route={route}>
+                            {routeComponent}
+                        </RouteComponentLifecycleWrapper>
+                    );
                 }}
             />
         );
     };
 };
 
-internals.RouteComponentLifecycleWrapper = class RouteComponentLifecycleWrapper extends React.PureComponent {
+const { useEffect, useState } = React;
 
-    constructor(props) {
+internals.RouteComponentLifecycleWrapper = function RouteComponentLifecycleWrapper(props) {
 
-        super();
+    const { route, ...rest } = props;
+    const { props: routeProps } = route;
 
-        const { route } = props;
+    const withRouteProps = { route, ...routeProps, ...rest };
 
-        if (route.componentDidCatch) {
-            this.componentDidCatch = (err, info) => route.componentDidCatch({ err, info, ...this.props });
+    let {
+        onMount,
+        onUnmount
+    } = route;
+
+    const { pre } = route;
+
+    const noop = () => null;
+
+    onMount = onMount || noop;
+    onUnmount = onUnmount || noop;
+
+    const [preResolved, setPreResolved] = useState(false);
+
+    useEffect(() => {
+
+        const runPre = async (func) => {
+
+            await func(withRouteProps);
+            onMount(withRouteProps);
+            setPreResolved(true);
+        };
+
+        if (!pre) {
+            onMount(withRouteProps);
+            setPreResolved(true);
+        }
+        else {
+            runPre(pre);
         }
 
-        if (route.onWillMount) {
-            this.componentWillMount = () => route.onWillMount(this.props);
-        }
+        return function cleanup() {
 
-        if (route.onDidMount) {
-            this.componentDidMount = () => route.onDidMount(this.props);
-        }
+            onUnmount(withRouteProps);
+        };
+    }, []);
 
-        if (route.onWillUnmount) {
-            this.componentWillUnmount = () => route.onWillUnmount(this.props);
-        }
-    }
+    const { fallback, children } = withRouteProps;
 
-    render() {
-
-        return this.props.children;
-    }
+    return !preResolved ? (fallback || null) : children;
 };
 
 internals.RouteComponentLifecycleWrapper.propTypes = {
-    route: PropTypes.object.isRequired
+    route: T.object.isRequired
 };
 
-internals.RouteComponentLifecycleWrapper.nonTrivial = (route) => {
+internals.RouteComponentLifecycleWrapper.trivial = (route) => {
 
-    return route.componentDidCatch ||
-        route.onWillMount ||
-        route.onDidMount ||
-        route.onWillUnmount;
+    return !route.props && !route.pre && !route.onMount && !route.onUnmount;
 };
 
 internals.concatPaths = (base, path) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,7 @@ internals.keyForRoute = (route) => {
 
     return String(
         route.path
+        + String(route.props)
         + !!route.exact
         + !!route.strict
         + !!route.sensitive

--- a/lib/index.js
+++ b/lib/index.js
@@ -107,16 +107,20 @@ internals.renderRoute = function renderRoute(basePath) {
                         : null;
 
                     const routeComponent = RouteComponent
-                        ? <RouteComponent {...props} route={route} children={switcher} />
+                        ? (
+                            <RouteComponent {...props} route={route}>
+                                {switcher}
+                            </RouteComponent>
+                        )
                         : switcher;
 
                     if (RouteComponentLifecycleWrapper.trivial(route)) {
-                        return routeComponent;
+                        return React.cloneElement(routeComponent, { route });
                     }
 
                     return (
-                        <RouteComponentLifecycleWrapper {...props} route={route}>
-                            {routeComponent}
+                        <RouteComponentLifecycleWrapper {...props} {...route.props} route={route}>
+                            {React.cloneElement(routeComponent, { route })}
                         </RouteComponentLifecycleWrapper>
                     );
                 }}
@@ -129,10 +133,7 @@ const { useEffect, useState } = React;
 
 internals.RouteComponentLifecycleWrapper = function RouteComponentLifecycleWrapper(props) {
 
-    const { route, ...rest } = props;
-    const { props: routeProps } = route;
-
-    const withRouteProps = { route, ...routeProps, ...rest };
+    const { route } = props;
 
     let {
         onMount,
@@ -152,13 +153,13 @@ internals.RouteComponentLifecycleWrapper = function RouteComponentLifecycleWrapp
 
         const runPre = async (func) => {
 
-            await func(withRouteProps);
-            onMount(withRouteProps);
+            await func(props);
+            onMount(props);
             setPreResolved(true);
         };
 
         if (!pre) {
-            onMount(withRouteProps);
+            onMount(props);
             setPreResolved(true);
         }
         else {
@@ -167,13 +168,15 @@ internals.RouteComponentLifecycleWrapper = function RouteComponentLifecycleWrapp
 
         return function cleanup() {
 
-            onUnmount(withRouteProps);
+            onUnmount(props);
         };
     }, []);
 
-    const { fallback, children } = withRouteProps;
+    const { fallback, children } = props;
 
-    return !preResolved ? (fallback || null) : children;
+    const toRender = !preResolved ? (fallback || null) : children;
+
+    return React.cloneElement(toRender, { route });
 };
 
 internals.RouteComponentLifecycleWrapper.propTypes = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -131,7 +131,7 @@ internals.renderRoute = function renderRoute(basePath) {
 
                         return (
                             <RouteComponent {...routerProps}>
-                                {!route.childRoutes ? null : (
+                                {route.childRoutes && (
                                     <Switch>
                                         {route.childRoutes.map(renderRouteFromPath)}
                                     </Switch>


### PR DESCRIPTION
### Towards `v3.0`

Summary:
> Swap classes for functional components, update the API

#### Changes
- Replace `PropTypes` with `T`
- Update the base `<Switch>` to set keys for children via `React.cloneElement`. I'm not exactly sure why, but the keys set for the `<Route>` components in `renderRoute` don't translate or something? I'm noticing an error anyway in an app about needing to specify unique keys for children — `strange-router` is in the stacktrace. This is a bug that needs to be fixed and I guess this fixes it? 🤷‍♂️
- Add a `props` key for route configs — any properties defined here will be spread into all the lifecycle hooks and `strange-router` supported methods that receive props.
- Add a `pre` hook to route configs to allow you to run an async function _before_ the route gets mounted. This can be useful if you have some data you require to be fetched before the route is rendered, to pull out of redux or wherever.
  - The route will render a component if one is specified in `route.fallback`.  `route.props.fallback` is also supported. For example a combination of `pre` and `route.fallback` might look like:

```js
{
    path: '/app',
    component: AppLayout,
    props: { ... },
    fallback: LoadingFallback,
    wrapFallbackWithComponent: true,
    pre: async ({ history: { replace } }) => {

        try {
            await settleAuth();
        }
        catch (ignoreErr) {
            replace('/login');
        }
    },
    onMount: () => startSomething(),
    onUnmount: () => stopSomething(),
    childRoutes: [
        ...
    ]
}
```

#### Breaking changes
- Change API for routes by simplifying the supported route lifecycle hooks. Instead of `onDidMount`, etc. we only have `onMount` and `onUnmount`.
- Removed support for the following route config options:
`componentDidCatch` // Add your own error boundary. There should really only be one at the app root
`onWillMount`
`onDidMount`
`onWillUnmount `

#### Route config supported keys are now:
`path`
`component`
`props`
`pre` (accepts async func)
`fallback` (also accepts `props.fallback`)
`wrapFallbackWithComponent`
`onMount`
`onUnmount`
`childRoutes`

TODO
- Update the README
- Add pre response to props somewhere (Might as well)